### PR TITLE
ci: fix sync-submodules workflow

### DIFF
--- a/.github/workflows/sync-submodules.yml
+++ b/.github/workflows/sync-submodules.yml
@@ -10,11 +10,13 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          submodules: recursive
+          submodules: true
           fetch-depth: 0
 
       - name: Configure git


### PR DESCRIPTION
## Problem
Workflow has been failing on every scheduled run (20+ consecutive failures) since at least 2026-05-30.

Exact error:
```
fatal: No url found for submodule path 'Project-JARVIS/jarvis/SuperMCP/.mcps/ShellMCP' in .gitmodules
fatal: Failed to recurse into submodule path 'Project-JARVIS/jarvis/SuperMCP'
fatal: Failed to recurse into submodule path 'Project-JARVIS'
```

Secondary issues:
- Missing `permissions: contents: write` — GITHUB_TOKEN only had `read`, so `git push` would also fail
- `actions/checkout@v4` uses Node.js 20, deprecated June 16 2026 (13 days away)

## Root Cause
`submodules: recursive` caused checkout to recurse into `Project-JARVIS/jarvis/SuperMCP`, which contains a nested submodule `ShellMCP` that has no registered URL in `.gitmodules`. Git exits 128.

## Fix
1. `submodules: recursive` → `submodules: true` — only initialises top-level submodules (`Project-JARVIS`, `dispatch`, `dmcp`, `linux-jarvisos`); the workflow only needs to bump those anyway
2. Added `permissions: contents: write` to the job
3. Bumped `actions/checkout@v4` → `@v6` (Node.js 24 compatible)

Note: `git submodule update --remote --merge` without `--recursive` already only updates top-level modules — no behaviour change for the actual sync logic.

## References
- Node.js 20 deprecation: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/