### PR TITLE
feat(security): add PolicyKit rules for JARVIS privilege escalation

### DIFF
--- a/packages/polkit/install.sh
+++ b/packages/polkit/install.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Install JARVIS PolicyKit rules and action definitions.
+# Must run as root.
+set -euo pipefail
+
+RULES_DIR="/usr/share/polkit-1/rules.d"
+ACTIONS_DIR="/usr/share/polkit-1/actions"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $EUID -ne 0 ]]; then
+    echo "error: must run as root" >&2
+    exit 1
+fi
+
+install -Dm644 "$SCRIPT_DIR/org.jarvisos.jarvis.rules"   "$RULES_DIR/org.jarvisos.jarvis.rules"
+install -Dm644 "$SCRIPT_DIR/jarvis-actions.conf"         "$ACTIONS_DIR/org.jarvisos.jarvis.policy"
+
+# Reload polkit to pick up new rules
+if command -v pkaction &>/dev/null; then
+    pkill -HUP polkitd 2>/dev/null || true
+fi
+
+echo "JARVIS PolicyKit rules installed."

--- a/packages/polkit/jarvis-actions.conf
+++ b/packages/polkit/jarvis-actions.conf
@@ -1,0 +1,89 @@
+[org.jarvisos.jarvis.install-package]
+Description=Install a system package on behalf of JARVIS
+Message=JARVIS is requesting permission to install a package. Confirm only if you initiated this action.
+Vendor=JarvisOS
+VendorUrl=https://github.com/JarvisOSLinux
+IconName=security-high
+ImplicitAny=no
+ImplicitInactive=no
+ImplicitActive=auth_admin_keep
+
+[org.jarvisos.jarvis.modify-system-config]
+Description=Modify a system configuration file on behalf of JARVIS
+Message=JARVIS is requesting permission to modify a system config. Confirm only if you initiated this action.
+Vendor=JarvisOS
+VendorUrl=https://github.com/JarvisOSLinux
+IconName=security-high
+ImplicitAny=no
+ImplicitInactive=no
+ImplicitActive=auth_admin_keep
+
+[org.jarvisos.jarvis.manage-services]
+Description=Start, stop, or restart a system service on behalf of JARVIS
+Message=JARVIS is requesting permission to manage a system service.
+Vendor=JarvisOS
+VendorUrl=https://github.com/JarvisOSLinux
+IconName=security-medium
+ImplicitAny=no
+ImplicitInactive=no
+ImplicitActive=auth_admin_keep
+
+[org.jarvisos.jarvis.network-config]
+Description=Modify network configuration on behalf of JARVIS
+Message=JARVIS is requesting permission to change network settings.
+Vendor=JarvisOS
+VendorUrl=https://github.com/JarvisOSLinux
+IconName=security-high
+ImplicitAny=no
+ImplicitInactive=no
+ImplicitActive=auth_admin_keep
+
+[org.jarvisos.jarvis.kernel-module]
+Description=Load or unload a kernel module on behalf of JARVIS
+Message=JARVIS is requesting permission to load a kernel module. This is a high-risk operation.
+Vendor=JarvisOS
+VendorUrl=https://github.com/JarvisOSLinux
+IconName=security-high
+ImplicitAny=no
+ImplicitInactive=no
+ImplicitActive=auth_admin
+
+[org.jarvisos.jarvis.read-system-info]
+Description=Read system information (CPU, memory, hardware) on behalf of JARVIS
+Message=JARVIS is requesting read access to system information.
+Vendor=JarvisOS
+VendorUrl=https://github.com/JarvisOSLinux
+IconName=dialog-information
+ImplicitAny=yes
+ImplicitInactive=yes
+ImplicitActive=yes
+
+[org.jarvisos.jarvis.read-logs]
+Description=Read system logs on behalf of JARVIS
+Message=JARVIS is requesting access to system logs.
+Vendor=JarvisOS
+VendorUrl=https://github.com/JarvisOSLinux
+IconName=dialog-information
+ImplicitAny=no
+ImplicitInactive=no
+ImplicitActive=yes
+
+[org.jarvisos.jarvis.manage-user-files]
+Description=Read or write user files on behalf of JARVIS
+Message=JARVIS is requesting access to your files.
+Vendor=JarvisOS
+VendorUrl=https://github.com/JarvisOSLinux
+IconName=security-medium
+ImplicitAny=no
+ImplicitInactive=no
+ImplicitActive=yes
+
+[org.jarvisos.jarvis.query]
+Description=Query PolicyKit about available JARVIS actions
+Message=JARVIS is querying its own permissions.
+Vendor=JarvisOS
+VendorUrl=https://github.com/JarvisOSLinux
+IconName=dialog-information
+ImplicitAny=yes
+ImplicitInactive=yes
+ImplicitActive=yes

--- a/packages/polkit/org.jarvisos.jarvis.rules
+++ b/packages/polkit/org.jarvisos.jarvis.rules
@@ -1,0 +1,86 @@
+// PolicyKit rules for the JARVIS AI daemon (org.jarvisos.jarvis)
+//
+// TLA tier mapping:
+//   SAFE      → no escalation needed
+//   ELEVATED  → audit log only
+//   DANGEROUS → requires explicit user confirmation (out-of-band, not from model output)
+//   FORBIDDEN → hard block, no escalation path
+//
+// The JARVIS daemon runs as a system service (jarvis.service).
+// It must not self-escalate. All privilege grants require the active
+// desktop session user to confirm via an out-of-band channel
+// (Textual modal, desktop notification, or stdin prompt).
+
+polkit.addRule(function(action, subject) {
+
+    // -------------------------------------------------------------------------
+    // Introspection: daemon may always query PolicyKit about its own actions
+    // -------------------------------------------------------------------------
+    if (action.id == "org.jarvisos.jarvis.query") {
+        return polkit.Result.YES;
+    }
+
+    // -------------------------------------------------------------------------
+    // ELEVATED tier — allowed automatically for the active session user.
+    // These are read-heavy or low-risk operations that the daemon performs
+    // on behalf of the logged-in user.  Audit logged by jarvis_policy.c.
+    // -------------------------------------------------------------------------
+    var elevatedActions = [
+        "org.jarvisos.jarvis.read-system-info",
+        "org.jarvisos.jarvis.read-logs",
+        "org.jarvisos.jarvis.manage-user-files",
+    ];
+
+    for (var i = 0; i < elevatedActions.length; i++) {
+        if (action.id == elevatedActions[i]) {
+            if (subject.isInGroup("jarvis-elevated") || subject.active) {
+                return polkit.Result.YES;
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // DANGEROUS tier — require explicit authentication from the active user.
+    // Polkit will surface a password/authentication dialog.  The JARVIS daemon
+    // must also receive an out-of-band confirmation from ConfirmationManager
+    // before calling the underlying privileged operation.
+    // -------------------------------------------------------------------------
+    var dangerousActions = [
+        "org.jarvisos.jarvis.install-package",
+        "org.jarvisos.jarvis.modify-system-config",
+        "org.jarvisos.jarvis.manage-services",
+        "org.jarvisos.jarvis.network-config",
+        "org.jarvisos.jarvis.kernel-module",
+    ];
+
+    for (var i = 0; i < dangerousActions.length; i++) {
+        if (action.id == dangerousActions[i]) {
+            if (subject.active && subject.local) {
+                // AUTH_ADMIN_KEEP: cached for the duration of the task only.
+                // The daemon is responsible for calling polkit_authority_revoke_tmp_authorizations()
+                // on task completion so the grant does not persist across sessions.
+                return polkit.Result.AUTH_ADMIN_KEEP;
+            }
+            return polkit.Result.NOT_HANDLED;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // FORBIDDEN tier — hard block.  No escalation path exists.
+    // Model output cannot trigger these.
+    // -------------------------------------------------------------------------
+    var forbiddenActions = [
+        "org.jarvisos.jarvis.modify-polkit-rules",
+        "org.jarvisos.jarvis.modify-sudo-config",
+        "org.jarvisos.jarvis.disable-security-modules",
+    ];
+
+    for (var i = 0; i < forbiddenActions.length; i++) {
+        if (action.id == forbiddenActions[i]) {
+            return polkit.Result.NO;
+        }
+    }
+
+    // Default: not handled — fall through to other rules or system defaults
+    return polkit.Result.NOT_HANDLED;
+});


### PR DESCRIPTION
## Summary

- Creates `packages/polkit/org.jarvisos.jarvis.rules` — JavaScript PolicyKit rules mapping JARVIS actions to the 4-tier TLA system (ELEVATED/DANGEROUS/FORBIDDEN)
- Creates `packages/polkit/jarvis-actions.conf` — PolicyKit action definition file with human-readable confirmation dialogs
- Creates `packages/polkit/install.sh` — install script that places files in `/usr/share/polkit-1/`

DANGEROUS-tier grants use `auth_admin_keep` which the daemon must revoke via `polkit_authority_revoke_tmp_authorizations()` on task completion — not session-persistent.

Model output cannot trigger FORBIDDEN-tier actions; hard `NO` is returned unconditionally.

## Test plan

- [ ] Install rules: `sudo bash packages/polkit/install.sh`
- [ ] Verify `pkaction --action-id org.jarvisos.jarvis.read-system-info` resolves
- [ ] Verify DANGEROUS action prompts for admin authentication
- [ ] Verify FORBIDDEN action returns NO without prompt

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)